### PR TITLE
Minor fix: supression for unchecked operation compilation warning

### DIFF
--- a/src/main/java/fr/theshark34/openlauncherlib/util/ramselector/OptionFrame.java
+++ b/src/main/java/fr/theshark34/openlauncherlib/util/ramselector/OptionFrame.java
@@ -50,6 +50,7 @@ public class OptionFrame extends AbstractOptionFrame
      *
      * @param selector The current Ram Selector
      */
+    @SuppressWarnings("unchecked")
     public OptionFrame(RamSelector selector)
     {
         super(selector);


### PR DESCRIPTION
Removed compilation warning by supressing the unchecked operation in OptionFrame class of ramselector utility.